### PR TITLE
Python 3 support and explicit TensorFlow dtypes

### DIFF
--- a/demo.ipynb
+++ b/demo.ipynb
@@ -56,7 +56,7 @@
     "model.train(inputs, targets)\n",
     "toc = time()\n",
     "\n",
-    "print 'Training took {} seconds.'.format(toc-tic)"
+    "print('Training took {} seconds.'.format(toc-tic))"
    ]
   },
   {
@@ -75,7 +75,7 @@
     "tic = time()\n",
     "predictions = generator.run(input_)\n",
     "toc = time()\n",
-    "print 'Generating took {} seconds.'.format(toc-tic)"
+    "print('Generating took {} seconds.'.format(toc-tic))"
    ]
   }
  ],

--- a/wavenet/layers.py
+++ b/wavenet/layers.py
@@ -24,7 +24,7 @@ def time_to_batch(inputs, rate):
 
     zeros = tf.zeros(shape=(batch_size, pad_left, channels))
     padded = tf.concat(1, (zeros, inputs))
-    padded_reshape = tf.reshape(padded, (batch_size * (width_pad / rate), rate,
+    padded_reshape = tf.reshape(padded, (batch_size * tf.to_int32((width_pad / rate)), rate,
                                          channels))
     outputs = tf.transpose(padded_reshape, perm=(1, 0, 2))
     return outputs, pad_left - rate
@@ -42,14 +42,14 @@ def batch_to_time(inputs, crop_left, rate):
     Ouputs:
       outputs: (tensor)
     '''
-    batch_size = tf.shape(inputs)[0] / rate
+    batch_size = tf.to_int32(tf.shape(inputs)[0] / rate)
     width = tf.shape(inputs)[1]
     _, _, channels = inputs.get_shape().as_list()
     out_width = tf.to_int32(width * rate)
 
     inputs_transposed = tf.transpose(inputs, perm=(1, 0, 2))
     inputs_reshaped = tf.reshape(inputs_transposed,
-                                 (batch_size, out_width, channels))
+                                 (batch_size, out_width, tf.to_int32(channels)))
     outputs = tf.slice(inputs_reshaped, [0, crop_left, 0], [-1, -1, -1])
     return outputs
 

--- a/wavenet/models.py
+++ b/wavenet/models.py
@@ -72,7 +72,7 @@ class Generator(object):
         inputs = tf.placeholder(tf.float32, [batch_size, input_size],
                                 name='inputs')
 
-        print 'Make Generator.'
+        print('Make Generator.')
 
         count = 0
         h = inputs


### PR DESCRIPTION
Ran into some issues with TensorFlow complaining about data types (could be just a 0.10 issue), so explicitly set those where needed. Also added support for Python 3 (tested with 3.4.2)
