### PR TITLE
Python3 fix for integer division of shape by rate

### DIFF
--- a/wavenet/layers.py
+++ b/wavenet/layers.py
@@ -40,7 +40,7 @@ def batch_to_time(inputs, rate, crop_left=0):
       outputs: (tensor)
     '''
     shape = tf.shape(inputs)
-    batch_size = shape[0] / rate
+    batch_size = shape[0] // rate
     width = shape[1]
     
     out_width = tf.to_int32(width * rate)

--- a/wavenet/layers.py
+++ b/wavenet/layers.py
@@ -20,7 +20,7 @@ def time_to_batch(inputs, rate):
     pad_left = width_pad - width
 
     perm = (1, 0, 2)
-    shape = (width_pad / rate, -1, num_channels) # missing dim: batch_size * rate
+    shape = (width_pad // rate, -1, num_channels) # missing dim: batch_size * rate
     padded = tf.pad(inputs, [[0, 0], [pad_left, 0], [0, 0]])
     transposed = tf.transpose(padded, perm)
     reshaped = tf.reshape(transposed, shape)

--- a/wavenet/models.py
+++ b/wavenet/models.py
@@ -1,8 +1,8 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
-from layers import (_causal_linear, _output_linear, conv1d,
-                    dilated_conv1d)
+from wavenet.layers import (_causal_linear, _output_linear, conv1d,
+                            dilated_conv1d)
 
 
 class Model(object):

--- a/wavenet/models.py
+++ b/wavenet/models.py
@@ -13,7 +13,8 @@ class Model(object):
                  num_blocks=2,
                  num_layers=14,
                  num_hidden=128,
-                 gpu_fraction=1.0):
+                 gpu_fraction=1.0,
+                 tolerance=1e-1):
         
         self.num_time_samples = num_time_samples
         self.num_channels = num_channels
@@ -22,6 +23,7 @@ class Model(object):
         self.num_layers = num_layers
         self.num_hidden = num_hidden
         self.gpu_fraction = gpu_fraction
+        self.tolerance = tolerance
         
         inputs = tf.placeholder(tf.float32,
                                 shape=(None, num_time_samples, num_channels))
@@ -77,7 +79,7 @@ class Model(object):
         while not terminal:
             i += 1
             cost = self._train(inputs, targets)
-            if cost < 1e-1:
+            if cost < self.tolerance:
                 terminal = True
             losses.append(cost)
             if i % 50 == 0:


### PR DESCRIPTION
The semantics of integer division have changed from python2 to python3:
Under python2:

```
5 / 2 == 2
5 // 2 == 2
```

while under python3

```
5 / 2 == 2.5
5 // 2 == 2
```

This PR fixes the issue with integer division of `shape` by `rate`, which causes `time_to_batch` and `batch_to_time` to raise an exception under python3, here's the stack trace:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-bc62c3c0b65b> in <module>()
      6 model = Model(num_time_samples=num_time_samples,
      7               num_channels=num_channels,
----> 8               gpu_fraction=gpu_fraction)
      9 
     10 Audio(inputs.reshape(inputs.shape[1]), rate=44100)

/Users/lantiga/Desktops/ZoneOut/fast-wavenet-2/wavenet/models.py in __init__(self, num_time_samples, num_channels, num_classes, num_blocks, num_layers, num_hidden, gpu_fraction)
     34                 rate = 2**i
     35                 name = 'b{}-l{}'.format(b, i)
---> 36                 h = dilated_conv1d(h, num_hidden, rate=rate, name=name)
     37                 hs.append(h)
     38 

/Users/lantiga/Desktops/ZoneOut/fast-wavenet-2/wavenet/layers.py in dilated_conv1d(inputs, out_channels, filter_width, rate, padding, name, gain, activation)
    136     with tf.variable_scope(name):
    137         _, width, _ = inputs.get_shape().as_list()
--> 138         inputs_ = time_to_batch(inputs, rate=rate)
    139         outputs_ = conv1d(inputs_,
    140                           out_channels=out_channels,

/Users/lantiga/Desktops/ZoneOut/fast-wavenet-2/wavenet/layers.py in time_to_batch(inputs, rate)
     24     padded = tf.pad(inputs, [[0, 0], [pad_left, 0], [0, 0]])
     25     transposed = tf.transpose(padded, perm)
---> 26     reshaped = tf.reshape(transposed, shape)
     27     outputs = tf.transpose(reshaped, perm)
     28     return outputs

/usr/local/lib/python3.5/site-packages/tensorflow/python/ops/gen_array_ops.py in reshape(tensor, shape, name)
   1756   """
   1757   result = _op_def_lib.apply_op("Reshape", tensor=tensor, shape=shape,
-> 1758                                 name=name)
   1759   return result
   1760 

/usr/local/lib/python3.5/site-packages/tensorflow/python/framework/op_def_library.py in apply_op(self, op_type_name, name, **keywords)
    452             values = ops.convert_to_tensor(
    453                 values, name=input_arg.name, dtype=dtype,
--> 454                 as_ref=input_arg.is_ref)
    455           except ValueError:
    456             # What type does convert_to_tensor think it has?

/usr/local/lib/python3.5/site-packages/tensorflow/python/framework/ops.py in convert_to_tensor(value, dtype, name, as_ref)
    626     for base_type, conversion_func in funcs_at_priority:
    627       if isinstance(value, base_type):
--> 628         ret = conversion_func(value, dtype=dtype, name=name, as_ref=as_ref)
    629         if ret is NotImplemented:
    630           continue

/usr/local/lib/python3.5/site-packages/tensorflow/python/framework/constant_op.py in _constant_tensor_conversion_function(v, dtype, name, as_ref)
    178                                          as_ref=False):
    179   _ = as_ref
--> 180   return constant(v, dtype=dtype, name=name)
    181 
    182 

/usr/local/lib/python3.5/site-packages/tensorflow/python/framework/constant_op.py in constant(value, dtype, shape, name)
    161   tensor_value = attr_value_pb2.AttrValue()
    162   tensor_value.tensor.CopyFrom(
--> 163       tensor_util.make_tensor_proto(value, dtype=dtype, shape=shape))
    164   dtype_value = attr_value_pb2.AttrValue(type=tensor_value.tensor.dtype)
    165   const_tensor = g.create_op(

/usr/local/lib/python3.5/site-packages/tensorflow/python/framework/tensor_util.py in make_tensor_proto(values, dtype, shape)
    351       nparray = np.empty(shape, dtype=np_dt)
    352     else:
--> 353       _AssertCompatible(values, dtype)
    354       nparray = np.array(values, dtype=np_dt)
    355       # check to them.

/usr/local/lib/python3.5/site-packages/tensorflow/python/framework/tensor_util.py in _AssertCompatible(values, dtype)
    288     else:
    289       raise TypeError("Expected %s, got %s of type '%s' instead." %
--> 290                       (dtype.name, repr(mismatch), type(mismatch).__name__))
    291 
    292 

TypeError: Expected int32, got 35316.0 of type 'float' instead.
```
